### PR TITLE
Fix PWA configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,24 +1,18 @@
 import withPWA from 'next-pwa';
 
-// Configuration options for Next.js
-const nextConfig = {
+// Combine Next.js configuration with the PWA plugin
+const nextConfig = withPWA({
   reactStrictMode: true, // Enable React strict mode for improved error handling
-  swcMinify: true,      // Enable SWC minification for improved performance
+  swcMinify: true, // Enable SWC minification for improved performance
   compiler: {
-    removeConsole: process.env.NODE_ENV !== "development", // Remove console.log in production
+    removeConsole: process.env.NODE_ENV !== 'development', // Remove console.log in production
   },
-};
-
-// Configuration object tells the next-pwa plugin 
-const withPWAConfig = withPWA({
-  dest: "public", // Destination directory for the PWA files
-  disable: process.env.NODE_ENV === "development", // Disable PWA in development mode
-  register: true, // Register the PWA service worker
-  skipWaiting: true, // Skip waiting for service worker activation
+  pwa: {
+    dest: 'public', // Destination directory for the PWA files
+    disable: process.env.NODE_ENV === 'development', // Disable PWA in development mode
+    register: true, // Register the PWA service worker
+    skipWaiting: true, // Skip waiting for service worker activation
+  },
 });
 
-// Combine the Next.js configuration with PWA configuration
-const finalConfig = withPWAConfig(nextConfig);
-
-// Export the combined configuration
-export default finalConfig;
+export default nextConfig;

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "NOT Price",
+  "short_name": "NOT Price",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "any",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "/28850.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure next-pwa via `pwa` option
- add missing `manifest.json`

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6887aa6862308322a8835358ab5721f8